### PR TITLE
fix: preserve root-level model config in agent creation

### DIFF
--- a/lib/utils/version_factory.py
+++ b/lib/utils/version_factory.py
@@ -175,7 +175,14 @@ class VersionFactory:
         """Create versioned agent using dynamic Agno proxy with inheritance support."""
 
         # Extract agent-specific config if full config provided
-        agent_config = config.get("agent", config) if "agent" in config else config
+        if "agent" in config:
+            agent_config = config["agent"].copy()  # Start with agent section
+            # Merge in root-level configurations (model, tools, etc.)
+            for key in config:
+                if key != "agent" and key not in agent_config:
+                    agent_config[key] = config[key]
+        else:
+            agent_config = config
         
         # Apply inheritance from team configuration if agent is part of a team
         inherited_config = self._apply_team_inheritance(component_id, agent_config)


### PR DESCRIPTION
## Summary
- Fixes issue where agents were being created with `model=None` despite having valid model configurations in YAML files
- The version factory was only extracting the "agent" section, causing root-level configurations to be lost

## Changes
- Modified `lib/utils/version_factory.py` to properly merge root-level configurations (like `model:`, `tools:`, etc.) into the agent config
- Root-level configs are merged while giving precedence to values in the "agent" section

## Test Plan
- [ ] Verify agents load with correct model configurations from YAML files
- [ ] Confirm root-level configs are preserved
- [ ] Check that "agent" section values still take precedence when conflicts exist

🤖 Generated with [Claude Code](https://claude.ai/code)