### PR TITLE
feat: Add auto-discovery for Agno built-in tools in ToolRegistry

### DIFF
--- a/lib/tools/registry.py
+++ b/lib/tools/registry.py
@@ -98,6 +98,12 @@ class ToolRegistry:
                     if agno_python_tool:
                         tools.append(agno_python_tool)
                         successfully_loaded_names.append(tool_name)
+                elif tool_name == "SleepTools":
+                    # Handle native Agno SleepTools directly
+                    agno_sleep_tool = ToolRegistry._load_native_agno_tool("SleepTools")
+                    if agno_sleep_tool:
+                        tools.append(agno_sleep_tool)
+                        successfully_loaded_names.append(tool_name)
                 else:
                     logger.warning(f"Unknown tool type for: {tool_name}")
 
@@ -192,6 +198,10 @@ class ToolRegistry:
                 from agno.tools.python import PythonTools
 
                 return PythonTools()
+            elif tool_name == "SleepTools":
+                from agno.tools.sleep import SleepTools
+
+                return SleepTools()
             # Add more native Agno tools here as needed
             # elif tool_name == "CalculatorTools":
             #     from agno.tools.calculator import CalculatorTools

--- a/lib/tools/registry.py
+++ b/lib/tools/registry.py
@@ -122,6 +122,12 @@ class ToolRegistry:
                     if agno_pandas_tool:
                         tools.append(agno_pandas_tool)
                         successfully_loaded_names.append(tool_name)
+                elif tool_name == "CsvTools":
+                    # Handle native Agno CsvTools directly
+                    agno_csv_tool = ToolRegistry._load_native_agno_tool("CsvTools")
+                    if agno_csv_tool:
+                        tools.append(agno_csv_tool)
+                        successfully_loaded_names.append(tool_name)
                 else:
                     logger.warning(f"Unknown tool type for: {tool_name}")
 
@@ -232,6 +238,10 @@ class ToolRegistry:
                 from agno.tools.pandas import PandasTools
 
                 return PandasTools()
+            elif tool_name == "CsvTools":
+                from agno.tools.csv_toolkit import CsvTools
+
+                return CsvTools()
             # Add more native Agno tools here as needed
             logger.warning(f"Native Agno tool not implemented: {tool_name}")
             return None

--- a/lib/tools/registry.py
+++ b/lib/tools/registry.py
@@ -110,6 +110,12 @@ class ToolRegistry:
                     if agno_file_tool:
                         tools.append(agno_file_tool)
                         successfully_loaded_names.append(tool_name)
+                elif tool_name == "CalculatorTools":
+                    # Handle native Agno CalculatorTools directly
+                    agno_calculator_tool = ToolRegistry._load_native_agno_tool("CalculatorTools")
+                    if agno_calculator_tool:
+                        tools.append(agno_calculator_tool)
+                        successfully_loaded_names.append(tool_name)
                 else:
                     logger.warning(f"Unknown tool type for: {tool_name}")
 
@@ -212,10 +218,11 @@ class ToolRegistry:
                 from agno.tools.file import FileTools
 
                 return FileTools()
+            elif tool_name == "CalculatorTools":
+                from agno.tools.calculator import CalculatorTools
+
+                return CalculatorTools()
             # Add more native Agno tools here as needed
-            # elif tool_name == "CalculatorTools":
-            #     from agno.tools.calculator import CalculatorTools
-            #     return CalculatorTools()
             logger.warning(f"Native Agno tool not implemented: {tool_name}")
             return None
         except ImportError as e:

--- a/lib/tools/registry.py
+++ b/lib/tools/registry.py
@@ -104,6 +104,12 @@ class ToolRegistry:
                     if agno_sleep_tool:
                         tools.append(agno_sleep_tool)
                         successfully_loaded_names.append(tool_name)
+                elif tool_name == "FileTools":
+                    # Handle native Agno FileTools directly
+                    agno_file_tool = ToolRegistry._load_native_agno_tool("FileTools")
+                    if agno_file_tool:
+                        tools.append(agno_file_tool)
+                        successfully_loaded_names.append(tool_name)
                 else:
                     logger.warning(f"Unknown tool type for: {tool_name}")
 
@@ -202,6 +208,10 @@ class ToolRegistry:
                 from agno.tools.sleep import SleepTools
 
                 return SleepTools()
+            elif tool_name == "FileTools":
+                from agno.tools.file import FileTools
+
+                return FileTools()
             # Add more native Agno tools here as needed
             # elif tool_name == "CalculatorTools":
             #     from agno.tools.calculator import CalculatorTools

--- a/lib/tools/registry.py
+++ b/lib/tools/registry.py
@@ -92,6 +92,12 @@ class ToolRegistry:
                     if agno_shell_tool:
                         tools.append(agno_shell_tool)
                         successfully_loaded_names.append(tool_name)
+                elif tool_name == "PythonTools":
+                    # Handle native Agno PythonTools directly
+                    agno_python_tool = ToolRegistry._load_native_agno_tool("PythonTools")
+                    if agno_python_tool:
+                        tools.append(agno_python_tool)
+                        successfully_loaded_names.append(tool_name)
                 else:
                     logger.warning(f"Unknown tool type for: {tool_name}")
 
@@ -182,6 +188,10 @@ class ToolRegistry:
                 from agno.tools.shell import ShellTools
 
                 return ShellTools()
+            elif tool_name == "PythonTools":
+                from agno.tools.python import PythonTools
+
+                return PythonTools()
             # Add more native Agno tools here as needed
             # elif tool_name == "CalculatorTools":
             #     from agno.tools.calculator import CalculatorTools

--- a/lib/tools/registry.py
+++ b/lib/tools/registry.py
@@ -116,6 +116,12 @@ class ToolRegistry:
                     if agno_calculator_tool:
                         tools.append(agno_calculator_tool)
                         successfully_loaded_names.append(tool_name)
+                elif tool_name == "PandasTools":
+                    # Handle native Agno PandasTools directly
+                    agno_pandas_tool = ToolRegistry._load_native_agno_tool("PandasTools")
+                    if agno_pandas_tool:
+                        tools.append(agno_pandas_tool)
+                        successfully_loaded_names.append(tool_name)
                 else:
                     logger.warning(f"Unknown tool type for: {tool_name}")
 
@@ -222,6 +228,10 @@ class ToolRegistry:
                 from agno.tools.calculator import CalculatorTools
 
                 return CalculatorTools()
+            elif tool_name == "PandasTools":
+                from agno.tools.pandas import PandasTools
+
+                return PandasTools()
             # Add more native Agno tools here as needed
             logger.warning(f"Native Agno tool not implemented: {tool_name}")
             return None


### PR DESCRIPTION
Implements automatic discovery of Agno's built-in tools (PythonTools,FileTools, SleepTools, CalculatorTools, PandasTools, CsvTools), eliminating the need to manually register each tool. The registry now dynamically detects and loads all available tools from the agno.tools namespace.