### PR TITLE
feat: resolve CORS configuration for agno.os integration

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -72,15 +72,24 @@ def create_app() -> FastAPI:
     app.include_router(protected_router)
 
     # Add Middlewares
+    # Note: allow_credentials=True is incompatible with allow_origins=["*"]
+    # Browsers reject this combination as a security measure
+    cors_origins = api_settings.cors_origin_list if api_settings.cors_origin_list else ["*"]
+    use_credentials = "*" not in cors_origins
+
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=api_settings.cors_origin_list
-        if api_settings.cors_origin_list
-        else ["*"],
-        allow_credentials=True,
+        allow_origins=cors_origins,
+        allow_credentials=use_credentials,
         allow_methods=["*"],
         allow_headers=["*"],
     )
+
+    if not use_credentials:
+        logger.debug(
+            "CORS credentials disabled due to wildcard origin",
+            origins=cors_origins
+        )
 
     return app
 

--- a/api/serve.py
+++ b/api/serve.py
@@ -762,13 +762,23 @@ async def _async_create_automagik_api():
     app.add_middleware(AgentRunErrorHandler)
 
     # Add CORS middleware
+    # Note: allow_credentials=True is incompatible with allow_origins=["*"]
+    # Browsers reject this combination as a security measure
+    use_credentials = "*" not in api_settings.cors_origin_list
+
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=api_settings.cors_origin_list,  # No ["*"] fallback
-        allow_credentials=True,
+        allow_origins=api_settings.cors_origin_list,
+        allow_credentials=use_credentials,
         allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
         allow_headers=["*"],
     )
+
+    if not use_credentials:
+        logger.debug(
+            "CORS credentials disabled due to wildcard origin",
+            origins=api_settings.cors_origin_list
+        )
 
     # Switch from startup to runtime logging mode
     from lib.logging import set_runtime_mode


### PR DESCRIPTION
## Summary
Resolves CORS configuration issues for agno.os integration in development mode.

## Problem
The existing CORS configuration had two critical issues preventing agno.os integration:
1. **Development mode override**: `HIVE_CORS_ORIGINS` was ignored in development, forcing wildcard `["*"]`
2. **Credentials conflict**: Browsers reject `allow_credentials=True` with `allow_origins=["*"]`

## Solution
1. **Respect explicit origins**: Check `HIVE_CORS_ORIGINS` first, fallback to wildcard only when unset
2. **Conditional credentials**: Automatically disable credentials when using wildcard origins
3. **Consistent behavior**: Applied to both `api/serve.py` and `api/main.py`

## Changes
- `api/settings.py`: Reordered CORS validator to prioritize explicit origins
- `api/serve.py`: Added conditional `allow_credentials` logic
- `api/main.py`: Same conditional credentials handling
- `tests/api/test_settings.py`: Updated tests + new explicit origins test

## Testing
✅ All 25 API settings tests passing
✅ Verified CORS headers with agno.os origin
✅ Confirmed unauthorized origins properly blocked
✅ Development server running without errors

## Test Results
```bash
# Authorized origin (agno.os)
curl -i http://localhost:8886/api/v1/health -H 'Origin: https://os.agno.com'
✅ access-control-allow-credentials: true
✅ access-control-allow-origin: https://os.agno.com

# Unauthorized origin
curl -i http://localhost:8886/api/v1/health -H 'Origin: https://unauthorized.com'
✅ No access-control-allow-origin header (properly blocked)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Automagik Genie <genie@namastex.ai>