### PR TITLE
Correct agent ID serialization in AgentOS API

### DIFF
--- a/lib/utils/proxy_agents.py
+++ b/lib/utils/proxy_agents.py
@@ -257,7 +257,8 @@ class AgnoAgentProxy:
         # Add runtime parameters
         agent_params.update(
             {
-                "agent_id": component_id,
+                "id": component_id,  # Used by AgentOS for API serialization
+                "agent_id": component_id,  # Used internally by Agno
                 "session_id": session_id,
                 "debug_mode": debug_mode,
                 "user_id": user_id,
@@ -420,10 +421,9 @@ class AgnoAgentProxy:
         _safe_model_cfg = str(model_config).replace("{", "{{").replace("}", "}}")
         _prov = model_config.get("provider")
         _log = logger.bind(provider=_prov) if _prov is not None else logger
-        _log.info(
-            f"🔍 TEMPLATE-AGENT MODEL CONFIG for {component_id}: {_safe_model_cfg}"
+        _log.debug(
+            f"🔍 Model configuration for {component_id}: {_safe_model_cfg}"
         )
-        print(f"🔍 TEMPLATE-AGENT MODEL CONFIG for {component_id}: {_safe_model_cfg}")
         
         model_id = model_config.get("id")
         provider = model_config.get("provider")


### PR DESCRIPTION
## Summary
This PR corrects agent ID serialization in the AgentOS API.

## Problem
The `/agents` API endpoint was returning model IDs (e.g., `gpt-5`) instead of agent IDs (e.g., `template-agent`) in the `id` field.

## Root Cause
AgentOS serialization uses `agent.id` which defaults to the model ID if not explicitly set. Our agent proxy was only setting `agent_id` but not `id`.

## Solution
Modified `lib/utils/proxy_agents.py` to explicitly set both parameters during agent creation:

```python
agent_params.update({
    "id": component_id,         # Used by AgentOS for API serialization
    "agent_id": component_id,   # Used internally by Agno
    "session_id": session_id,
    "debug_mode": debug_mode,
    "user_id": user_id,
})
```

## Changes
- Set both `id` and `agent_id` parameters in agent creation
- Remove debug print statement from model config handler
- Change log message from "TEMPLATE-AGENT MODEL CONFIG" to "Model configuration"
- Change log level from `info` to `debug` for cleaner output

## Impact
**Before:**
```json
{"id": "gpt-5", "name": "🔧 Template Agent"}
```

**After:**
```json
{"id": "template-agent", "name": "🔧 Template Agent"}
```

## Files Changed
- `lib/utils/proxy_agents.py` - Agent ID serialization logic

## Test Plan
- [x] Verify `/agents` endpoint returns correct agent IDs
- [x] Confirm all existing agents load successfully
- [x] Validate API response structure
- [x] Test agent creation and configuration

## Verification
```bash
curl http://localhost:8886/agents | jq '.[] | {id: .id, name: .name}'
# Output now correctly shows agent IDs instead of model IDs
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
