### PR TITLE
feat: Template distribution for uvx automagik-hive init
      support

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -117,6 +117,8 @@ Use --help for detailed options or see documentation.
     init_parser = subparsers.add_parser("init", help="Initialize new workspace with AI templates")
     init_parser.add_argument("workspace", nargs="?", default="my-hive-workspace",
                             help="Workspace name (default: my-hive-workspace)")
+    init_parser.add_argument("--force", action="store_true",
+                            help="Overwrite existing workspace (requires confirmation)")
 
     # Install subcommand
     install_parser = subparsers.add_parser(
@@ -249,7 +251,8 @@ def main() -> int:
         if args.command == "init":
             service_manager = ServiceManager()
             workspace = getattr(args, 'workspace', 'my-hive-workspace') or 'my-hive-workspace'
-            return 0 if service_manager.init_workspace(workspace) else 1
+            force = getattr(args, 'force', False)
+            return 0 if service_manager.init_workspace(workspace, force=force) else 1
 
         # Install subcommand
         if args.command == "install":


### PR DESCRIPTION
## Summary

      Implements template packaging and discovery to enable `uvx automagik-hive init
      <folder>` to work from anywhere without requiring the source repository.

      Fixes #60

      ## Changes

      ### 🎯 Core Implementation

      **1. Template Packaging** (`pyproject.toml`)
      - Added `[tool.hatch.build.targets.wheel.shared-data]` configuration
      - Packages templates into `automagik_hive/templates/` directory in wheel
      - Includes: template-agent, template-team, template-workflow, .env.example

      **2. Smart Template Discovery** (`cli/commands/service.py`)
      - New `_locate_template_root()` method with fallback strategy:
        1. First tries source directory (development mode)
        2. Falls back to package resources via `importlib.resources`
      - Supports both Python 3.9+ and 3.8 resource APIs
      - Provides clear error messages when templates not found

      **3. Force Overwrite Flag** (`cli/commands/service.py`, `cli/main.py`)
      - Added `--force` flag to `init` command
      - Requires explicit "yes" confirmation before overwriting
      - Safely removes existing workspace before creating new one
      - Usage: `automagik-hive init my-project --force`

      **4. Template Version Tracking** (`cli/commands/service.py`)
      - New `_create_workspace_metadata()` method
      - Generates `.automagik-hive-workspace.yml` in each workspace
      - Tracks:
        - `template_version`: Template compatibility version (1.0.0)
        - `hive_version`: Version of Automagik Hive used
        - `created_at`: ISO timestamp of workspace creation
      - Foundation for future template upgrade detection

      ### 🧪 Testing

      **New Tests** (`tests/cli/commands/test_service.py`):
      1. ✅ `test_init_workspace_force_overwrite` - Force flag with confirmation
      2. ✅ `test_init_workspace_force_cancelled` - Force flag but user cancels
      3. ✅ `test_locate_template_root_source` - Template discovery from source
      4. ✅ `test_create_workspace_metadata` - Metadata file generation

      **Updated Tests**:
      - Updated existing init tests to work with new signature
      - All 7 tests passing ✅

      ### 📊 Test Results

      ```bash
      ============================= test session starts ==============================
      tests/cli/commands/test_service.py::TestServiceManagerInitWorkspace::test_init_workspa
      ce_already_exists PASSED
      tests/cli/commands/test_service.py::TestServiceManagerInitWorkspace::test_init_workspa
      ce_force_overwrite PASSED
      tests/cli/commands/test_service.py::TestServiceManagerInitWorkspace::test_init_workspa
      ce_force_cancelled PASSED
      tests/cli/commands/test_service.py::TestServiceManagerInitWorkspace::test_init_workspa
      ce_exception_handling PASSED
      tests/cli/commands/test_service.py::TestServiceManagerInitWorkspace::test_init_workspa
      ce_basic_structure PASSED
      tests/cli/commands/test_service.py::TestServiceManagerInitWorkspace::test_locate_templ
      ate_root_source PASSED
      tests/cli/commands/test_service.py::TestServiceManagerInitWorkspace::test_create_works
      pace_metadata PASSED

      ========================= 7 passed in 2.89s =========================
      ```

      ## Usage Examples

      ### Basic Usage (New User Experience)
      ```bash
      # From anywhere - no repo clone needed!
      uvx automagik-hive init my-project
      cd my-project
      cp .env.example .env
      # Edit .env with your API keys
      uvx automagik-hive install
      uvx automagik-hive dev
      ```

      ### Force Overwrite Existing Workspace
      ```bash
      # Overwrite with confirmation
      automagik-hive init my-project --force
      # User prompted: "Type 'yes' to confirm overwrite: "
      ```

      ### Generated Workspace Structure
      ```
      my-project/
      ├── .automagik-hive-workspace.yml  # NEW: Version tracking
      ├── .env.example
      ├── ai/
      │   ├── agents/
      │   │   └── template-agent/
      │   ├── teams/
      │   │   └── template-team/
      │   └── workflows/
      │       └── template-workflow/
      └── knowledge/
          └── .gitkeep
      ```

      ### Workspace Metadata Example
      ```yaml
      template_version: '1.0.0'
      hive_version: 0.1.1b2
      created_at: '2025-10-18T19:24:15.123456+00:00'
      description: Automagik Hive workspace metadata
      ```

      ## Technical Details

      ### Template Discovery Logic
      ```python
      def _locate_template_root(self) -> Path | None:
          # 1. Try source directory (development)
          if (source_templates / "agents" / "template-agent").exists():
              return source_templates

          # 2. Try package resources (uvx/pip install)
          template_path = files('automagik_hive') / 'templates'
          if template_path.exists():
              return template_path

          return None
      ```

      ### Package Distribution
      - Templates embedded in wheel via `shared-data`
      - Accessible via `importlib.resources`
      - No runtime downloads required
      - Works offline after installation

      ## Benefits

      ✅ **Zero-friction onboarding** - `uvx automagik-hive init` works instantly
      ✅ **No repository cloning** - Templates bundled with package
      ✅ **Offline support** - No network calls after install
      ✅ **Version tracking** - Foundation for template upgrades
      ✅ **Force overwrite** - Easy workspace reset/update
      ✅ **Cross-platform** - Works on Linux, macOS, Windows
      ✅ **CI/CD friendly** - Deterministic workspace creation

      ## Breaking Changes

      None - fully backward compatible with existing workflows.

      ## Future Enhancements (Not in this PR)

      Documented in #60 for future implementation:
      - Custom template sources (URLs, local paths)
      - Template registry (minimal, enterprise variants)
      - `upgrade-templates` command for existing workspaces
      - End-to-end integration test (init→install→dev)

      ## Checklist

      - [x] Code implements all core functionality
      - [x] Tests added and passing (7/7 ✅)
      - [x] Backward compatible
      - [x] pyproject.toml updated for template packaging
      - [x] Error messages are helpful and actionable
      - [x] Works in both development and package modes
      - [ ] Documentation updates (will follow in separate PR)

      ## Related

      - Fixes #60 - Template distribution for uvx support
      - Built on top of #57 - Init command foundation

      ## Screenshots

      ### Before (Error)
      ```
      $ uvx automagik-hive init my-project
      ⚠️  Warning: No templates were copied (not found in project)
      ```

      ### After (Success)
      ```
      $ uvx automagik-hive init my-project
      🏗️  Initializing workspace: my-project
      📋 This will copy AI component templates only
      💡 You'll need to run 'install' afterwards for full setup

        ✅ Agent template
        ✅ Team template
        ✅ Workflow template
        ✅ Environment template (.env.example)
        ✅ Workspace metadata

      ✅ Workspace initialized: my-project
      ```