### PR TITLE
Add .gitignore for Node.js and PGlite files

### DIFF
--- a/tools/pglite-bridge/.gitignore
+++ b/tools/pglite-bridge/.gitignore
@@ -1,0 +1,17 @@
+# Node.js dependencies
+node_modules/
+package-lock.json
+
+# PGlite database data
+pglite-data/
+
+# Runtime files
+pglite-bridge.log
+pglite-bridge.pid
+
+# npm debug logs
+npm-debug.log*
+
+# Generic log and PID files
+*.log
+*.pid


### PR DESCRIPTION
Fixes #80

Created .gitignore file in tools/pglite-bridge/ directory to prevent auto-generated files from being tracked by git.

This includes:
- Node.js dependencies (node_modules/, package-lock.json)
- PGlite database files (pglite-data/)
- Runtime files (*.log, *.pid)
- npm debug logs