### PR TITLE
fix: Add custom @tool function loading from ai/tools package

### DIFF
--- a/lib/tools/registry.py
+++ b/lib/tools/registry.py
@@ -105,14 +105,21 @@ class ToolRegistry:
                         tools.append(tool)
                         successfully_loaded_names.append(tool_name)
                 else:
-                    # Try to load as native Agno tool via auto-discovery
-                    agno_tool = ToolRegistry._load_native_agno_tool(tool_name, tool_options)
-                    if agno_tool:
-                        tools.append(agno_tool)
+                    # Try to load as custom @tool decorated function from ai/tools/
+                    custom_tool = ToolRegistry._load_custom_tool(tool_name)
+                    if custom_tool:
+                        tools.append(custom_tool)
                         successfully_loaded_names.append(tool_name)
-                        logger.debug(f"🔧 Loaded native Agno tool: {tool_name}")
+                        logger.debug(f"🔧 Loaded custom @tool: {tool_name}")
                     else:
-                        logger.warning(f"Unknown tool type for: {tool_name}")
+                        # Try to load as native Agno tool via auto-discovery
+                        agno_tool = ToolRegistry._load_native_agno_tool(tool_name, tool_options)
+                        if agno_tool:
+                            tools.append(agno_tool)
+                            successfully_loaded_names.append(tool_name)
+                            logger.debug(f"🔧 Loaded native Agno tool: {tool_name}")
+                        else:
+                            logger.warning(f"Unknown tool type for: {tool_name}")
 
             except Exception as e:
                 logger.error(f"Failed to load tool {tool_name}: {e}")
@@ -367,6 +374,33 @@ class ToolRegistry:
         ToolRegistry._agno_tools_cache = discovered_tools
         logger.debug(f"🔧 Discovered {len(discovered_tools)} Agno Tools: {sorted(discovered_tools.keys())}")
         return discovered_tools
+
+    @staticmethod
+    def _load_custom_tool(tool_name: str) -> Callable:
+        """Load repo-defined Agno @tool functions exposed under ai.tools.* packages."""
+        try:
+            import ai.tools  # Ensure package is importable
+        except ImportError as e:
+            logger.debug(f"ai.tools package unavailable for custom tool loading: {e}")
+            return None
+
+        for _finder, module_name, _ in pkgutil.walk_packages(ai.tools.__path__, "ai.tools."):
+            try:
+                module = importlib.import_module(module_name)
+            except Exception as e:
+                logger.debug(f"Error importing {module_name}: {e}")
+                continue
+
+            if not hasattr(module, tool_name):
+                continue
+
+            func = getattr(module, tool_name)
+            type_name = type(func).__name__
+            if type_name == "Function" or callable(func):
+                logger.debug(f"🔧 Found custom @tool '{tool_name}' in {module_name}")
+                return func
+
+        return None
 
     @staticmethod
     def _load_shared_tool(tool_name: str) -> Callable:


### PR DESCRIPTION
## Description

Fixes #94 

This PR enhances the ToolRegistry to support loading custom Agno @tool decorated functions defined in the repository's ai/tools package.

## Changes

- Added `_load_custom_tool()` method to scan ai.tools packages using pkgutil.walk_packages
- Discovers @tool decorated functions by checking type and callable status
- Integrated custom tool loading into the registry discovery chain
- Updated tool loading priority order: MCP -> Shared -> Custom -> Native Agno

## Impact

- Agents can now reference custom @tool functions directly in YAML configuration
- Enables domain-specific tool development without external tooling
- Maintains backward compatibility with existing MCP, shared, and native Agno tools

## Testing

- Custom tools are discovered and loaded correctly
- Tool loading order respects the priority chain
- Falls back to native Agno tools when custom tools not found

## Documentation

- Updated ai/tools/CLAUDE.md with comprehensive custom @tool decorator support section
- Added usage examples and best practices
- Included troubleshooting guide

Co-Authored-By: Claude <noreply@anthropic.com>